### PR TITLE
[chore] 공통 Unit Test Workflow 적용

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main, master]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test:
+    uses: kenshin579/actions/.github/workflows/unit-test-go.yml@main
+    with:
+      go_version: '1.24'
+      run_unit_tests: true
+      run_integration_tests: true
+      unit_test_args: '-v -short'
+      integration_test_args: '-v -run TestCacheRedisClusterStore'
+      coverage_enabled: true
+      docker_compose_file: 'docker-compose.yml'
+      post_comment: true


### PR DESCRIPTION
## Summary

- actions 저장소의 재사용 가능한 `unit-test-go.yml` workflow 추가
- Go 1.24 사용
- Unit Tests + Integration Tests (docker-compose) 실행
- Coverage 수집 활성화

## Test plan

- [ ] PR에서 Unit Tests 실행 확인
- [ ] PR에서 Integration Tests (Redis Cluster) 실행 확인
- [ ] PR 코멘트에 테스트 결과 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)